### PR TITLE
Implement command line parameter to configure rtp relay type.

### DIFF
--- a/src/org/jitsi/hammer/FakeUser.java
+++ b/src/org/jitsi/hammer/FakeUser.java
@@ -15,6 +15,7 @@
  */
 package org.jitsi.hammer;
 
+import net.java.sip.communicator.impl.protocol.jabber.extensions.jingleinfo.RelayPacketExtension;
 import org.jivesoftware.smack.*;
 import org.jivesoftware.smack.bosh.*;
 import org.jivesoftware.smack.packet.*;
@@ -354,6 +355,10 @@ public class FakeUser implements PacketListener
                 new ConferencePropertyPacketExtension(
                         "simulcastMode", 
                         this.conferenceInfo.getSimulcastMode()));
+        conferenceInitiationIQ.addConferenceProperty(
+                new ConferencePropertyPacketExtension(
+                        "rtpLevelRelayType",
+                        this.conferenceInfo.getRtpLevelRelayType()));
         try 
         {
             this.connection.sendPacket(conferenceInitiationIQ);

--- a/src/org/jitsi/hammer/utils/CmdLineArguments.java
+++ b/src/org/jitsi/hammer/utils/CmdLineArguments.java
@@ -224,7 +224,13 @@ public class CmdLineArguments
     @Option(name="-simulcastMode", usage="sets " +
             "'simulcastMode' conference parameter")
     private String simulcastMode = "rewriting";
-    
+
+    /**
+     * The "rtpLevelRelayType" conference property
+     */
+    @Option(name="-rtpLevelRelayType", usage="sets " +
+            "'rtpLevelRelayType' conference parameter")
+    private String rtpLevelRelayType = "translator";
 
     /**
      * Create a <tt>ConferenceInfo</tt> from the CLI options
@@ -240,7 +246,8 @@ public class CmdLineArguments
                 openSctp,
                 startAudioMuted,
                 startVideoMuted,
-                simulcastMode
+                simulcastMode,
+                rtpLevelRelayType
         );
     }
 

--- a/src/org/jitsi/hammer/utils/ConferenceInfo.java
+++ b/src/org/jitsi/hammer/utils/ConferenceInfo.java
@@ -59,6 +59,11 @@ public class ConferenceInfo {
     private String simulcastMode;
 
     /**
+     * The "rtpAudioRelayType" conference property
+     */
+    private String rtpLevelRelayType;
+
+    /**
      * Create new ConferenceInfo instance
      * 
      * @param channelLastN The "channelLastN" conference property
@@ -68,6 +73,7 @@ public class ConferenceInfo {
      * @param startAudioMuted The "startAudioMuted" conference property
      * @param startVideoMuted The "startVideoMuted" conference property
      * @param simulcastMode The "simulcastMode" conference property
+     * @param rtpLevelRelayType The "rtpAudioRelayType" conference property
      */
     public ConferenceInfo(
             String channelLastN,
@@ -76,7 +82,8 @@ public class ConferenceInfo {
             String openSctp,
             String startAudioMuted,
             String startVideoMuted,
-            String simulcastMode) 
+            String simulcastMode,
+            String rtpLevelRelayType)
     {
         this.channelLastN = channelLastN;
         this.adaptiveLastN = adaptiveLastN;
@@ -85,6 +92,7 @@ public class ConferenceInfo {
         this.startAudioMuted = startAudioMuted;
         this.startVideoMuted = startVideoMuted;
         this.simulcastMode = simulcastMode;
+        this.rtpLevelRelayType = rtpLevelRelayType;
     }
 
     /**
@@ -150,5 +158,11 @@ public class ConferenceInfo {
         return simulcastMode;
     }
     
-    
+    /**
+     * Get the "rtpAudioRelayType" conference property
+     *
+     * @return the "rtpAudioRelayType" conference property
+     */
+    public String getRtpLevelRelayType() { return rtpLevelRelayType; }
+
 }


### PR DESCRIPTION
Implement -rtpLevelRelayType command line parameter to specify which type of rtp relay should be used with the created conferences: translator (default) or mixer. 

NOTE: it requires https://github.com/jitsi/jitsi/pull/261 and https://github.com/jitsi/jicofo/pull/86.